### PR TITLE
fix base image to support nvcc out of the box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
+FROM pytorch/pytorch:2.4.1-cuda12.4-cudnn9-devel
 LABEL maintainer="prime genesys"
 LABEL repository="genesys"
 


### PR DESCRIPTION
the current docker image does not seem to work on most of the machines without adjusting the underlying machine (which is not very useful for a decentralized use-case). 

with the current image version `primeintellect/genesys:commit-bc10edd` the following error appears on the debug.conf: 
```
/bin/sh: 1: /usr/local/cuda/bin/nvcc: not found
```

the current change solves this issue. I have pushed a sample to: `jannikstprime/genesys:latest` 

