### PR TITLE
Add SimpleBench verifier

### DIFF
--- a/script/convert_simplebench.py
+++ b/script/convert_simplebench.py
@@ -1,0 +1,38 @@
+import argparse
+import json
+from pathlib import Path
+
+
+def convert_eval_data(eval_data):
+    for item in eval_data:
+        question_id = str(item["question_id"])
+        answer = item["answer"].strip().upper()
+        yield {
+            "problem_id": f"simplebench-{question_id}",
+            "source": "simple-bench/SimpleBench",
+            "task_type": "simple_bench",
+            "in_source_id": question_id,
+            "prompt": item["prompt"],
+            "gold_standard_solution": answer,
+            "verification_info": {"answer": answer},
+            "metadata": {"question_id": item["question_id"]},
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert SimpleBench JSON to Genesys task JSONL.")
+    parser.add_argument("input", type=Path, help="Path to simple_bench_public.json")
+    parser.add_argument("output", type=Path, help="Path to write Genesys-compatible JSONL")
+    args = parser.parse_args()
+
+    with args.input.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+
+    with args.output.open("w", encoding="utf-8") as f:
+        for task in convert_eval_data(payload["eval_data"]):
+            f.write(json.dumps(task, ensure_ascii=False))
+            f.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesys/verifiers/registry.py
+++ b/src/genesys/verifiers/registry.py
@@ -2,10 +2,12 @@ from genesys.verifiers.code_test_verifier import CodeVerifier
 from genesys.verifiers.math_verifier import MathVerifier
 from genesys.verifiers.llm_judge_verifier import LlmJudgeVerifier
 from genesys.verifiers.code_output_prediction_verifier import CodeUnderstandingVerifier
+from genesys.verifiers.simple_bench_verifier import SimpleBenchVerifier
 
 VERIFIER_REGISTRY = {
     "verifiable_code": CodeVerifier,
     "verifiable_math": MathVerifier,
     "llm_judgeable_groundtruth_similarity": LlmJudgeVerifier,
     "code_output_prediction": CodeUnderstandingVerifier,
+    "simple_bench": SimpleBenchVerifier,
 }

--- a/src/genesys/verifiers/simple_bench_verifier.py
+++ b/src/genesys/verifiers/simple_bench_verifier.py
@@ -1,0 +1,53 @@
+import re
+from typing import Dict
+
+from genesys.verifiers.base_verifier import BaseVerifier
+
+
+FINAL_ANSWER_PATTERNS = [
+    re.compile(r"final\s+answer\s*(?:is|:|-)?\s*\(?\s*([A-F])\s*\)?", re.IGNORECASE),
+    re.compile(r"answer\s*(?:is|:|-)?\s*\(?\s*([A-F])\s*\)?", re.IGNORECASE),
+]
+
+
+class SimpleBenchVerifier(BaseVerifier):
+    max_parallel = 30
+    timeout = 5
+
+    def verify(self, result: Dict):
+        expected = self._expected_answer(result)
+        extracted = self._extract_answer(result["llm_response"])
+
+        return dict(
+            score=int(extracted == expected),
+            verification_result_info={
+                "extracted_answer": extracted,
+                "expected_answer": expected,
+            },
+        )
+
+    def _expected_answer(self, result: Dict) -> str:
+        verification_info = result.get("verification_info", {})
+        answer = (
+            verification_info.get("answer")
+            or verification_info.get("ground_truth")
+            or result.get("gold_standard_solution")
+        )
+        if answer is None:
+            raise ValueError("SimpleBench responses require an expected A-F answer")
+
+        answer = str(answer).strip().upper()
+        if not re.fullmatch(r"[A-F]", answer):
+            raise ValueError(f"Invalid SimpleBench expected answer: {answer!r}")
+        return answer
+
+    def _extract_answer(self, response: str) -> str | None:
+        for pattern in FINAL_ANSWER_PATTERNS:
+            match = pattern.search(response)
+            if match:
+                return match.group(1).upper()
+
+        candidates = re.findall(r"\b([A-F])\b", response.upper())
+        if candidates:
+            return candidates[-1]
+        return None

--- a/tests/test_simple_bench_verifier.py
+++ b/tests/test_simple_bench_verifier.py
@@ -1,0 +1,34 @@
+from genesys.verifiers.simple_bench_verifier import SimpleBenchVerifier
+
+
+def make_result(llm_response, answer="C"):
+    return {
+        "llm_response": llm_response,
+        "verification_info": {"answer": answer},
+        "gold_standard_solution": answer,
+    }
+
+
+def test_simple_bench_verifier_accepts_final_answer_format():
+    verifier = SimpleBenchVerifier()
+
+    result = verifier.verify(make_result("Reasoning...\nFinal Answer: C"))
+
+    assert result["score"] == 1
+    assert result["verification_result_info"]["extracted_answer"] == "C"
+
+
+def test_simple_bench_verifier_accepts_parenthesized_answer():
+    verifier = SimpleBenchVerifier()
+
+    result = verifier.verify(make_result("After checking the options, final answer is (c)."))
+
+    assert result["score"] == 1
+
+
+def test_simple_bench_verifier_rejects_wrong_answer():
+    verifier = SimpleBenchVerifier()
+
+    result = verifier.verify(make_result("Final Answer: B"))
+
+    assert result["score"] == 0


### PR DESCRIPTION
Adds SimpleBench support for Genesys tasks.

Changes:
- register a `simple_bench` verifier
- score A-F final-answer responses
- add a converter from SimpleBench JSON to Genesys JSONL
- add focused verifier tests

Verification:
- `python -m py_compile src/genesys/verifiers/simple_bench_verifier.py script/convert_simplebench.py tests/test_simple_bench_verifier.py`
- direct SimpleBenchVerifier assertions locally

Note: `pytest` was not available in the local environment.